### PR TITLE
Hyperstack fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>sc.fiji</groupId>
 		<artifactId>pom-fiji</artifactId>
-		<version>17.0.0</version>
+		<version>24.0.0</version>
 		<relativePath />
 	</parent>
 

--- a/src/main/java/sc/fiji/localThickness/Clean_Up_Local_Thickness.java
+++ b/src/main/java/sc/fiji/localThickness/Clean_Up_Local_Thickness.java
@@ -145,8 +145,14 @@ public class Clean_Up_Local_Thickness implements PlugInFilter {
 			} // j
 		} // k
 		IJ.showStatus("Clean Up Local Thickness complete");
+
 		final String title = stripExtension(imp.getTitle());
-		resultImage = new ImagePlus(title + "_CL", newStack);
+		final int slices = imp.getNSlices();
+		final int channels = imp.getNChannels();
+		final int frames = imp.getNFrames();
+
+		resultImage = IJ.createHyperStack(title + "_CL", w, h, channels, slices, frames, 32);
+		resultImage.setStack(newStack, channels, slices, frames);
 		resultImage.getProcessor().setMinAndMax(0, 2 * imp.getProcessor().getMax());
 
 		if (!runSilent) {

--- a/src/main/java/sc/fiji/localThickness/Distance_Ridge.java
+++ b/src/main/java/sc/fiji/localThickness/Distance_Ridge.java
@@ -232,8 +232,14 @@ public class Distance_Ridge implements PlugInFilter {
 			} // j
 		} // k
 		IJ.showStatus("Distance Ridge complete");
+
 		final String title = stripExtension(imp.getTitle());
-		resultImage = new ImagePlus(title + "_DR", newStack);
+		final int slices = imp.getNSlices();
+		final int channels = imp.getNChannels();
+		final int frames = imp.getNFrames();
+
+		resultImage = IJ.createHyperStack(title  + "_DR", w, h, channels, slices, frames, 32);
+		resultImage.setStack(newStack, channels, slices, frames);
 		resultImage.getProcessor().setMinAndMax(0, distMax);
 
 		if (!runSilent) {

--- a/src/main/java/sc/fiji/localThickness/EDT_S1D.java
+++ b/src/main/java/sc/fiji/localThickness/EDT_S1D.java
@@ -197,8 +197,14 @@ public class EDT_S1D implements PlugInFilter {
 
 		IJ.showProgress(1.0);
 		IJ.showStatus("Done");
+
 		final String title = stripExtension(imp.getTitle());
-		resultImage = new ImagePlus(title + "_EDT", sStack);
+		final int slices = imp.getNSlices();
+		final int channels = imp.getNChannels();
+		final int frames = imp.getNFrames();
+
+		resultImage = IJ.createHyperStack(title + "_EDT", w, h, channels, slices, frames, 32);
+		resultImage.setStack(sStack, channels, slices, frames);
 		resultImage.getProcessor().setMinAndMax(0, distMax);
 
 		if (!runSilent) {

--- a/src/main/java/sc/fiji/localThickness/LocalThicknessWrapper.java
+++ b/src/main/java/sc/fiji/localThickness/LocalThicknessWrapper.java
@@ -114,15 +114,9 @@ public class LocalThicknessWrapper implements PlugIn {
 	public ImagePlus processImage(final ImagePlus inputImage) {
 		String originalTitle = Local_Thickness_Driver.stripExtension(inputImage
 			.getTitle());
-		final ImagePlus image = inputImage.duplicate();
-
 		resultImage = null;
 
-		if (originalTitle == null || originalTitle.isEmpty()) {
-			originalTitle = DEFAULT_TITLE;
-		}
-
-		geometryToDistancePlugin.setup("", image);
+		geometryToDistancePlugin.setup("", inputImage);
 		if (!showOptions) {
 			// set options programmatically
 			geometryToDistancePlugin.inverse = inverse;
@@ -159,11 +153,11 @@ public class LocalThicknessWrapper implements PlugIn {
 		if (maskThicknessMap) {
 			thicknessMask.inverse = inverse;
 			thicknessMask.threshold = threshold;
-			resultImage = thicknessMask.trimOverhang(image, resultImage);
+			resultImage = thicknessMask.trimOverhang(inputImage, resultImage);
 		}
 
 		resultImage.setTitle(originalTitle + titleSuffix);
-		resultImage.copyScale(image);
+		resultImage.copyScale(inputImage);
 
 		if (calibratePixels) {
 			calibratePixels();
@@ -241,8 +235,6 @@ public class LocalThicknessWrapper implements PlugIn {
 		if (titleSuffix == null || titleSuffix.isEmpty()) {
 			titleSuffix = DEFAULT_TITLE_SUFFIX;
 		}
-
-		assert titleSuffix != null && !this.titleSuffix.isEmpty();
 	}
 
 	/**

--- a/src/main/java/sc/fiji/localThickness/Local_Thickness_Parallel.java
+++ b/src/main/java/sc/fiji/localThickness/Local_Thickness_Parallel.java
@@ -179,6 +179,7 @@ public class Local_Thickness_Parallel implements PlugInFilter {
 			}
 		}
 		IJ.showStatus("Local Thickness complete");
+
 		final String title = stripExtension(imp.getTitle());
 		resultImage.setTitle(title + "_LT");
 		resultImage.getProcessor().setMinAndMax(0, sMax);

--- a/src/main/java/sc/fiji/localThickness/MaskThicknessMapWithOriginal.java
+++ b/src/main/java/sc/fiji/localThickness/MaskThicknessMapWithOriginal.java
@@ -90,11 +90,10 @@ public class MaskThicknessMapWithOriginal {
 				"The dimensions of the images do not match");
 		}
 
-		final ImageStack originalStack = original.getImageStack();
-
 		resultImage = thicknessMap.duplicate();
-		resultImage.setTitle(thicknessMap.getTitle()); // duplicate() adds DUP_ to
-																										// title
+		resultImage.setTitle(thicknessMap.getTitle() + "_MASK");
+
+		final ImageStack originalStack = original.getImageStack();
 		final ImageStack resultStack = resultImage.getImageStack();
 
 		ImageProcessor originalProcessor;


### PR DESCRIPTION
Fix the plugins so that if the input image is a hyperstack the resulting images are hyperstacks. The plugin is not designed to work with these kinds of images so unfortunately it produces incorrect results.
