### PR TITLE
Improve memory handling of Local Thickness

### DIFF
--- a/src/main/java/sc/fiji/localThickness/Clean_Up_Local_Thickness.java
+++ b/src/main/java/sc/fiji/localThickness/Clean_Up_Local_Thickness.java
@@ -75,7 +75,6 @@ public class Clean_Up_Local_Thickness implements PlugInFilter {
 	private ImagePlus resultImage;
 
 	public float[][] s, sNew;
-	public int w, h, d;
 	public boolean runSilent = false;
 
 	@Override
@@ -89,9 +88,10 @@ public class Clean_Up_Local_Thickness implements PlugInFilter {
 		resultImage = null;
 
 		final ImageStack stack = imp.getStack();
-		w = stack.getWidth();
-		h = stack.getHeight();
-		d = imp.getStackSize();
+		final int w = stack.getWidth();
+		final int h = stack.getHeight();
+		final int d = imp.getStackSize();
+		
 		// Create 32 bit floating point stack for output, sNew.
 		final ImageStack newStack = new ImageStack(w, h);
 		sNew = new float[d][];
@@ -110,8 +110,9 @@ public class Clean_Up_Local_Thickness implements PlugInFilter {
 		// s (input data) for an interior non-background point
 		for (int k = 0; k < d; k++) {
 			for (int j = 0; j < h; j++) {
+				final int wj = w * j;
 				for (int i = 0; i < w; i++) {
-					sNew[k][i + w * j] = setFlag(i, j, k);
+					sNew[k][i + wj] = setFlag(i, j, k, w, h, d);
 				} // i
 			} // j
 		} // k
@@ -127,10 +128,11 @@ public class Clean_Up_Local_Thickness implements PlugInFilter {
 			// the averaging.
 		for (int k = 0; k < d; k++) {
 			for (int j = 0; j < h; j++) {
+				final int wj = w * j;
 				for (int i = 0; i < w; i++) {
-					final int ind = i + w * j;
+					final int ind = i + wj;
 					if (sNew[k][ind] == -1) {
-						sNew[k][ind] = -averageInteriorNeighbors(i, j, k);
+						sNew[k][ind] = -averageInteriorNeighbors(i, j, k, w, h, d);
 					}
 				} // i
 			} // j
@@ -138,8 +140,9 @@ public class Clean_Up_Local_Thickness implements PlugInFilter {
 			// Fix the negative values and double the results
 		for (int k = 0; k < d; k++) {
 			for (int j = 0; j < h; j++) {
+				final int wj = w * j;
 				for (int i = 0; i < w; i++) {
-					final int ind = i + w * j;
+					final int ind = i + wj;
 					sNew[k][ind] = Math.abs(sNew[k][ind]);
 				} // i
 			} // j
@@ -161,176 +164,176 @@ public class Clean_Up_Local_Thickness implements PlugInFilter {
 		}
 	}
 
-	float setFlag(final int i, final int j, final int k) {
+	float setFlag(final int i, final int j, final int k, final int w, final int h, final int d) {
 		if (s[k][i + w * j] == 0) return 0;
 		// change 1
-		if (look(i, j, k - 1) == 0) return -1;
-		if (look(i, j, k + 1) == 0) return -1;
-		if (look(i, j - 1, k) == 0) return -1;
-		if (look(i, j + 1, k) == 0) return -1;
-		if (look(i - 1, j, k) == 0) return -1;
-		if (look(i + 1, j, k) == 0) return -1;
+		if (look(i, j, k - 1, w, h, d) == 0) return -1;
+		if (look(i, j, k + 1, w, h, d) == 0) return -1;
+		if (look(i, j - 1, k, w, h, d) == 0) return -1;
+		if (look(i, j + 1, k, w, h, d) == 0) return -1;
+		if (look(i - 1, j, k, w, h, d) == 0) return -1;
+		if (look(i + 1, j, k, w, h, d) == 0) return -1;
 		// change 1 before plus
-		if (look(i, j + 1, k - 1) == 0) return -1;
-		if (look(i, j + 1, k + 1) == 0) return -1;
-		if (look(i + 1, j - 1, k) == 0) return -1;
-		if (look(i + 1, j + 1, k) == 0) return -1;
-		if (look(i - 1, j, k + 1) == 0) return -1;
-		if (look(i + 1, j, k + 1) == 0) return -1;
+		if (look(i, j + 1, k - 1, w, h, d) == 0) return -1;
+		if (look(i, j + 1, k + 1, w, h, d) == 0) return -1;
+		if (look(i + 1, j - 1, k, w, h, d) == 0) return -1;
+		if (look(i + 1, j + 1, k, w, h, d) == 0) return -1;
+		if (look(i - 1, j, k + 1, w, h, d) == 0) return -1;
+		if (look(i + 1, j, k + 1, w, h, d) == 0) return -1;
 		// change 1 before minus
-		if (look(i, j - 1, k - 1) == 0) return -1;
-		if (look(i, j - 1, k + 1) == 0) return -1;
-		if (look(i - 1, j - 1, k) == 0) return -1;
-		if (look(i - 1, j + 1, k) == 0) return -1;
-		if (look(i - 1, j, k - 1) == 0) return -1;
-		if (look(i + 1, j, k - 1) == 0) return -1;
+		if (look(i, j - 1, k - 1, w, h, d) == 0) return -1;
+		if (look(i, j - 1, k + 1, w, h, d) == 0) return -1;
+		if (look(i - 1, j - 1, k, w, h, d) == 0) return -1;
+		if (look(i - 1, j + 1, k, w, h, d) == 0) return -1;
+		if (look(i - 1, j, k - 1, w, h, d) == 0) return -1;
+		if (look(i + 1, j, k - 1, w, h, d) == 0) return -1;
 		// change 3, k+1
-		if (look(i + 1, j + 1, k + 1) == 0) return -1;
-		if (look(i + 1, j - 1, k + 1) == 0) return -1;
-		if (look(i - 1, j + 1, k + 1) == 0) return -1;
-		if (look(i - 1, j - 1, k + 1) == 0) return -1;
+		if (look(i + 1, j + 1, k + 1, w, h, d) == 0) return -1;
+		if (look(i + 1, j - 1, k + 1, w, h, d) == 0) return -1;
+		if (look(i - 1, j + 1, k + 1, w, h, d) == 0) return -1;
+		if (look(i - 1, j - 1, k + 1, w, h, d) == 0) return -1;
 		// change 3, k-1
-		if (look(i + 1, j + 1, k - 1) == 0) return -1;
-		if (look(i + 1, j - 1, k - 1) == 0) return -1;
-		if (look(i - 1, j + 1, k - 1) == 0) return -1;
-		if (look(i - 1, j - 1, k - 1) == 0) return -1;
+		if (look(i + 1, j + 1, k - 1, w, h, d) == 0) return -1;
+		if (look(i + 1, j - 1, k - 1, w, h, d) == 0) return -1;
+		if (look(i - 1, j + 1, k - 1, w, h, d) == 0) return -1;
+		if (look(i - 1, j - 1, k - 1, w, h, d) == 0) return -1;
 		return s[k][i + w * j];
 	}
 
-	float averageInteriorNeighbors(final int i, final int j, final int k) {
+	float averageInteriorNeighbors(final int i, final int j, final int k, final int w, final int h, final int d) {
 		int n = 0;
 		float sum = 0;
 		// change 1
-		float value = lookNew(i, j, k - 1);
+		float value = lookNew(i, j, k - 1, w, h, d);
 		if (value > 0) {
 			n++;
 			sum += value;
 		}
-		value = lookNew(i, j, k + 1);
+		value = lookNew(i, j, k + 1, w, h, d);
 		if (value > 0) {
 			n++;
 			sum += value;
 		}
-		value = lookNew(i, j - 1, k);
+		value = lookNew(i, j - 1, k, w, h, d);
 		if (value > 0) {
 			n++;
 			sum += value;
 		}
-		value = lookNew(i, j + 1, k);
+		value = lookNew(i, j + 1, k, w, h, d);
 		if (value > 0) {
 			n++;
 			sum += value;
 		}
-		value = lookNew(i - 1, j, k);
+		value = lookNew(i - 1, j, k, w, h, d);
 		if (value > 0) {
 			n++;
 			sum += value;
 		}
-		value = lookNew(i + 1, j, k);
+		value = lookNew(i + 1, j, k, w, h, d);
 		if (value > 0) {
 			n++;
 			sum += value;
 		}
 		// change 1 before plus
-		value = lookNew(i, j + 1, k - 1);
+		value = lookNew(i, j + 1, k - 1, w, h, d);
 		if (value > 0) {
 			n++;
 			sum += value;
 		}
-		value = lookNew(i, j + 1, k + 1);
+		value = lookNew(i, j + 1, k + 1, w, h, d);
 		if (value > 0) {
 			n++;
 			sum += value;
 		}
-		value = lookNew(i + 1, j - 1, k);
+		value = lookNew(i + 1, j - 1, k, w, h, d);
 		if (value > 0) {
 			n++;
 			sum += value;
 		}
-		value = lookNew(i + 1, j + 1, k);
+		value = lookNew(i + 1, j + 1, k, w, h, d);
 		if (value > 0) {
 			n++;
 			sum += value;
 		}
-		value = lookNew(i - 1, j, k + 1);
+		value = lookNew(i - 1, j, k + 1, w, h, d);
 		if (value > 0) {
 			n++;
 			sum += value;
 		}
-		value = lookNew(i + 1, j, k + 1);
+		value = lookNew(i + 1, j, k + 1, w, h, d);
 		if (value > 0) {
 			n++;
 			sum += value;
 		}
 		// change 1 before minus
-		value = lookNew(i, j - 1, k - 1);
+		value = lookNew(i, j - 1, k - 1, w, h, d);
 		if (value > 0) {
 			n++;
 			sum += value;
 		}
-		value = lookNew(i, j - 1, k + 1);
+		value = lookNew(i, j - 1, k + 1, w, h, d);
 		if (value > 0) {
 			n++;
 			sum += value;
 		}
-		value = lookNew(i - 1, j - 1, k);
+		value = lookNew(i - 1, j - 1, k, w, h, d);
 		if (value > 0) {
 			n++;
 			sum += value;
 		}
-		value = lookNew(i - 1, j + 1, k);
+		value = lookNew(i - 1, j + 1, k, w, h, d);
 		if (value > 0) {
 			n++;
 			sum += value;
 		}
-		value = lookNew(i - 1, j, k - 1);
+		value = lookNew(i - 1, j, k - 1, w, h, d);
 		if (value > 0) {
 			n++;
 			sum += value;
 		}
-		value = lookNew(i + 1, j, k - 1);
+		value = lookNew(i + 1, j, k - 1, w, h, d);
 		if (value > 0) {
 			n++;
 			sum += value;
 		}
 		// change 3, k+1
-		value = lookNew(i + 1, j + 1, k + 1);
+		value = lookNew(i + 1, j + 1, k + 1, w, h, d);
 		if (value > 0) {
 			n++;
 			sum += value;
 		}
-		value = lookNew(i + 1, j - 1, k + 1);
+		value = lookNew(i + 1, j - 1, k + 1, w, h, d);
 		if (value > 0) {
 			n++;
 			sum += value;
 		}
-		value = lookNew(i - 1, j + 1, k + 1);
+		value = lookNew(i - 1, j + 1, k + 1, w, h, d);
 		if (value > 0) {
 			n++;
 			sum += value;
 		}
-		value = lookNew(i - 1, j - 1, k + 1);
+		value = lookNew(i - 1, j - 1, k + 1, w, h, d);
 		if (value > 0) {
 			n++;
 			sum += value;
 		}
 		// change 3, k-1
-		value = lookNew(i + 1, j + 1, k - 1);
+		value = lookNew(i + 1, j + 1, k - 1, w, h, d);
 		if (value > 0) {
 			n++;
 			sum += value;
 		}
-		value = lookNew(i + 1, j - 1, k - 1);
+		value = lookNew(i + 1, j - 1, k - 1, w, h, d);
 		if (value > 0) {
 			n++;
 			sum += value;
 		}
-		value = lookNew(i - 1, j + 1, k - 1);
+		value = lookNew(i - 1, j + 1, k - 1, w, h, d);
 		if (value > 0) {
 			n++;
 			sum += value;
 		}
-		value = lookNew(i - 1, j - 1, k - 1);
+		value = lookNew(i - 1, j - 1, k - 1, w, h, d);
 		if (value > 0) {
 			n++;
 			sum += value;
@@ -339,7 +342,7 @@ public class Clean_Up_Local_Thickness implements PlugInFilter {
 		return s[k][i + w * j];
 	}
 
-	float look(final int i, final int j, final int k) {
+	float look(final int i, final int j, final int k, final int w, final int h, final int d) {
 		if ((i < 0) || (i >= w)) return -1;
 		if ((j < 0) || (j >= h)) return -1;
 		if ((k < 0) || (k >= d)) return -1;
@@ -347,7 +350,7 @@ public class Clean_Up_Local_Thickness implements PlugInFilter {
 	}
 
 	// A positive result means this is an interior, non-background, point.
-	float lookNew(final int i, final int j, final int k) {
+	float lookNew(final int i, final int j, final int k, final int w, final int h, final int d) {
 		if ((i < 0) || (i >= w)) return -1;
 		if ((j < 0) || (j >= h)) return -1;
 		if ((k < 0) || (k >= d)) return -1;

--- a/src/main/java/sc/fiji/localThickness/Clean_Up_Local_Thickness.java
+++ b/src/main/java/sc/fiji/localThickness/Clean_Up_Local_Thickness.java
@@ -369,4 +369,14 @@ public class Clean_Up_Local_Thickness implements PlugInFilter {
 	public ImagePlus getResultImage() {
 		return resultImage;
 	}
+
+	/**
+	 * Remove references to instance variables to allow garbage collection
+	 */
+	public void purge() {
+		s = null;
+		sNew = null;
+		resultImage = null;
+		imp = null;
+	}
 }

--- a/src/main/java/sc/fiji/localThickness/Distance_Ridge.java
+++ b/src/main/java/sc/fiji/localThickness/Distance_Ridge.java
@@ -85,7 +85,6 @@ public class Distance_Ridge implements PlugInFilter {
 	private ImagePlus resultImage;
 
 	public float[][] data;
-	public int w, h, d;
 	public boolean runSilent = false;
 
 	@Override
@@ -99,9 +98,9 @@ public class Distance_Ridge implements PlugInFilter {
 		resultImage = null;
 
 		final ImageStack stack = imp.getStack();
-		w = stack.getWidth();
-		h = stack.getHeight();
-		d = imp.getStackSize();
+		final int w = stack.getWidth();
+		final int h = stack.getHeight();
+		final int d = imp.getStackSize();
 		// Create 32 bit floating point stack for output, s. Will also use it for g
 		// in Transormation 1.
 		final ImageStack newStack = new ImageStack(w, h);
@@ -127,9 +126,11 @@ public class Distance_Ridge implements PlugInFilter {
 		for (int k = 0; k < d; k++) {
 			sk = s[k];
 			for (int j = 0; j < h; j++) {
+				final int wj = w * j;
 				for (int i = 0; i < w; i++) {
-					final int ind = i + w * j;
-					if (sk[ind] > distMax) distMax = sk[ind];
+					final int ind = i + wj;
+					final float skind = sk[ind];
+					if (skind > distMax) distMax = skind;
 				}
 			}
 		}
@@ -140,9 +141,11 @@ public class Distance_Ridge implements PlugInFilter {
 		for (int k = 0; k < d; k++) {
 			sk = s[k];
 			for (int j = 0; j < h; j++) {
+				final int wj = w * j;
 				for (int i = 0; i < w; i++) {
-					final int ind = i + w * j;
-					occurs[(int) (sk[ind] * sk[ind] + 0.5f)] = true;
+					final int ind = i + wj;
+					final float skind = sk[ind];
+					occurs[(int) (skind * skind + 0.5f)] = true;
 				}
 			}
 		}
@@ -176,11 +179,13 @@ public class Distance_Ridge implements PlugInFilter {
 			sk = s[k];
 			skNew = sNew[k];
 			for (int j = 0; j < h; j++) {
+				final int wj = w * j;
 				for (int i = 0; i < w; i++) {
-					final int ind = i + w * j;
-					if (sk[ind] > 0) {
+					final int ind = i + wj;
+					final float skind = sk[ind];
+					if (skind > 0) {
 						notRidgePoint = false;
-						sk0Sq = (int) (sk[ind] * sk[ind] + 0.5f);
+						sk0Sq = (int) (skind * skind + 0.5f);
 						sk0SqInd = distSqIndex[sk0Sq];
 						for (dz = -1; dz <= 1; dz++) {
 							k1 = k + dz;
@@ -194,6 +199,7 @@ public class Distance_Ridge implements PlugInFilter {
 								}
 								for (dy = -1; dy <= 1; dy++) {
 									j1 = j + dy;
+									final int wj1 = w * j1;
 									if ((j1 >= 0) && (j1 < h)) {
 										if (dy == 0) {
 											numCompY = 0;
@@ -212,8 +218,8 @@ public class Distance_Ridge implements PlugInFilter {
 												}
 												numComp = numCompX + numCompY + numCompZ;
 												if (numComp > 0) {
-													sk1Sq = (int) (sk1[i1 + w * j1] * sk1[i1 + w * j1] +
-														0.5f);
+													final float sk1i1wj1 = sk1[i1 + wj1]; 
+													sk1Sq = (int) (sk1i1wj1 * sk1i1wj1 + 0.5f);
 													if (sk1Sq >= rSqTemplate[numComp - 1][sk0SqInd])
 														notRidgePoint = true;
 												}
@@ -285,17 +291,14 @@ public class Distance_Ridge implements PlugInFilter {
 				final int rSq = distSqValues[rSqInd];
 				int max = 0;
 				final int r = 1 + (int) Math.sqrt(rSq);
-				int scank, scankj;
 				int dk, dkji;
-				final int iBall;
-				int iPlus;
 				for (int k = 0; k <= r; k++) {
-					scank = k * k;
+					final int scank = k * k;
 					dk = (k - dzAbs) * (k - dzAbs);
 					for (int j = 0; j <= r; j++) {
-						scankj = scank + j * j;
+						final int scankj = scank + j * j;
 						if (scankj <= rSq) {
-							iPlus = ((int) Math.sqrt(rSq - scankj)) - dxAbs;
+							final int iPlus = ((int) Math.sqrt(rSq - scankj)) - dxAbs;
 							dkji = dk + (j - dyAbs) * (j - dyAbs) + iPlus * iPlus;
 							if (dkji > max) max = dkji;
 						}

--- a/src/main/java/sc/fiji/localThickness/Distance_Ridge.java
+++ b/src/main/java/sc/fiji/localThickness/Distance_Ridge.java
@@ -321,4 +321,13 @@ public class Distance_Ridge implements PlugInFilter {
 	public ImagePlus getResultImage() {
 		return resultImage;
 	}
+
+	/**
+	 * Remove references to instance variables to allow garbage collection
+	 */
+	public void purge() {
+		data = null;
+		resultImage = null;
+		imp = null;
+	}
 }

--- a/src/main/java/sc/fiji/localThickness/EDT_S1D.java
+++ b/src/main/java/sc/fiji/localThickness/EDT_S1D.java
@@ -86,7 +86,6 @@ public class EDT_S1D implements PlugInFilter {
 	private boolean cancelled;
 
 	public byte[][] data;
-	public int w, h, d;
 	public int thresh = DEFAULT_THRESHOLD;
 	public boolean inverse = DEFAULT_INVERSE;
 	public boolean showOptions = true;
@@ -104,9 +103,9 @@ public class EDT_S1D implements PlugInFilter {
 		resultImage = null;
 
 		final ImageStack stack = imp.getStack();
-		w = stack.getWidth();
-		h = stack.getHeight();
-		d = imp.getStackSize();
+		final int w = stack.getWidth();
+		final int h = stack.getHeight();
+		final int d = imp.getStackSize();
 		final int nThreads = Runtime.getRuntime().availableProcessors();
 
 		cancelled = false;
@@ -282,8 +281,9 @@ public class EDT_S1D implements PlugInFilter {
 				sk = s[k];
 				dk = data[k];
 				for (int j = 0; j < h; j++) {
+					final int wj = w * j;
 					for (int i = 0; i < w; i++) {
-						background[i] = ((dk[i + w * j] & 255) < thresh) ^ inverse;
+						background[i] = ((dk[i + wj] & 255) < thresh) ^ inverse;
 					}
 					for (int i = 0; i < w; i++) {
 						min = noResult;
@@ -303,7 +303,7 @@ public class EDT_S1D implements PlugInFilter {
 								break;
 							}
 						}
-						sk[i + w * j] = min;
+						sk[i + wj] = min;
 					}
 				}
 			}
@@ -397,10 +397,11 @@ public class EDT_S1D implements PlugInFilter {
 			int test, min, delta;
 			for (int j = thread; j < h; j += nThreads) {
 				IJ.showProgress(j / (1. * h));
+				final int wj = w * j;
 				for (int i = 0; i < w; i++) {
 					nonempty = false;
 					for (int k = 0; k < d; k++) {
-						tempS[k] = (int) s[k][i + w * j];
+						tempS[k] = (int) s[k][i + wj];
 						if (tempS[k] > 0) nonempty = true;
 					}
 					if (nonempty) {
@@ -415,7 +416,7 @@ public class EDT_S1D implements PlugInFilter {
 
 						for (int k = 0; k < d; k++) {
 							// Limit to the non-background to save time,
-							if (((data[k][i + w * j] & 255) >= thresh) ^ inverse) {
+							if (((data[k][i + wj] & 255) >= thresh) ^ inverse) {
 								min = noResult;
 								zBegin = zStart;
 								zEnd = zStop;
@@ -431,7 +432,7 @@ public class EDT_S1D implements PlugInFilter {
 							}
 						}
 						for (int k = 0; k < d; k++) {
-							s[k][i + w * j] = tempInt[k];
+							s[k][i + wj] = tempInt[k];
 						}
 					}
 				}

--- a/src/main/java/sc/fiji/localThickness/EDT_S1D.java
+++ b/src/main/java/sc/fiji/localThickness/EDT_S1D.java
@@ -439,4 +439,13 @@ public class EDT_S1D implements PlugInFilter {
 			}
 		}// run
 	}// Step2Thread
+
+	/**
+	 * Remove references to instance variables to allow garbage collection
+	 */
+	public void purge() {
+		data = null;
+		resultImage = null;
+		imp = null;
+	}
 }

--- a/src/main/java/sc/fiji/localThickness/LocalThicknessWrapper.java
+++ b/src/main/java/sc/fiji/localThickness/LocalThicknessWrapper.java
@@ -188,11 +188,11 @@ public class LocalThicknessWrapper implements PlugInFilter {
 	 * Doing this prevents them from affecting statistical measures calculated
 	 * from the image, e.g. mean pixel value.
 	 *
-	 * @param backgroundColor The color used to identify background pixels
+	 * @param backgroundValue The color used to identify background pixels
 	 *          (usually 0x00)
 	 * @throws NullPointerException If this.resultImage == null
 	 */
-	private void backgroundToNaN(final int backgroundColor) {
+	private void backgroundToNaN(final int backgroundValue) {
 		if (resultImage == null) {
 			throw new NullPointerException(
 				"The resultImage in LocalThicknessWrapper is null");
@@ -205,7 +205,7 @@ public class LocalThicknessWrapper implements PlugInFilter {
 		for (int z = 1; z <= depth; z++) {
 			final float pixels[] = (float[]) stack.getPixels(z);
 			for (int i = 0; i < pixelsPerSlice; i++) {
-				if (Float.compare(pixels[i], backgroundColor) == 0) {
+				if (Float.compare(pixels[i], backgroundValue) == 0) {
 					pixels[i] = Float.NaN;
 				}
 			}
@@ -272,6 +272,6 @@ public class LocalThicknessWrapper implements PlugInFilter {
 		}
 
 		resultImage.show();
-		IJ.run("Fire"); // changes the color palette of the output image
+		IJ.run("Fire"); // changes the lookup table of the output image
 	}
 }

--- a/src/main/java/sc/fiji/localThickness/LocalThicknessWrapper.java
+++ b/src/main/java/sc/fiji/localThickness/LocalThicknessWrapper.java
@@ -247,7 +247,7 @@ public class LocalThicknessWrapper implements PlugInFilter {
 
 		double[] sliceMax = new double[depth];
 		sliceNumbers.parallelStream().forEach(z -> {
-			sliceMax[z] = stack.getProcessor(z).getMax();
+			sliceMax[z - 1] = stack.getProcessor(z).getMax();
 		});
 		
 		final double maxPixelValue = Arrays.stream(sliceMax).max().getAsDouble();

--- a/src/main/java/sc/fiji/localThickness/LocalThicknessWrapper.java
+++ b/src/main/java/sc/fiji/localThickness/LocalThicknessWrapper.java
@@ -27,7 +27,9 @@ import ij.ImagePlus;
 import ij.ImageStack;
 import ij.plugin.filter.PlugInFilter;
 import ij.process.ImageProcessor;
-import ij.process.StackStatistics;
+
+import java.util.ArrayList;
+import java.util.Arrays;
 
 /**
  * A class which can be used to programmatically run and control the various
@@ -49,19 +51,19 @@ import ij.process.StackStatistics;
 public class LocalThicknessWrapper implements PlugInFilter {
 
 	private static final String DEFAULT_TITLE_SUFFIX = "_LocThk";
-	private final EDT_S1D geometryToDistancePlugin = new EDT_S1D();
+	private EDT_S1D geometryToDistancePlugin = new EDT_S1D();
 	private ImagePlus image;
-	private final Distance_Ridge distanceRidgePlugin =
+	private Distance_Ridge distanceRidgePlugin =
 		new Distance_Ridge();
-	private final Local_Thickness_Parallel localThicknessPlugin =
+	private Local_Thickness_Parallel localThicknessPlugin =
 		new Local_Thickness_Parallel();
-	private final Clean_Up_Local_Thickness thicknessCleaningPlugin =
+	private Clean_Up_Local_Thickness thicknessCleaningPlugin =
 		new Clean_Up_Local_Thickness();
-	private final MaskThicknessMapWithOriginal thicknessMask =
+	private MaskThicknessMapWithOriginal thicknessMask =
 		new MaskThicknessMapWithOriginal();
 
 	/**
-	 * A pixel is considered to be a part of the background if its color &lt;
+	 * A pixel is considered to be a part of the background if its value &lt;
 	 * threshold
 	 */
 	public int threshold = EDT_S1D.DEFAULT_THRESHOLD;
@@ -133,7 +135,6 @@ public class LocalThicknessWrapper implements PlugInFilter {
 			// set options programmatically
 			geometryToDistancePlugin.inverse = inverse;
 			geometryToDistancePlugin.thresh = threshold;
-
 			geometryToDistancePlugin.run(null);
 		}
 		else {
@@ -149,23 +150,28 @@ public class LocalThicknessWrapper implements PlugInFilter {
 			threshold = geometryToDistancePlugin.thresh;
 		}
 		resultImage = geometryToDistancePlugin.getResultImage();
+		geometryToDistancePlugin.purge();
 
 		distanceRidgePlugin.setup("", resultImage);
 		distanceRidgePlugin.run(null);
 		resultImage = distanceRidgePlugin.getResultImage();
+		distanceRidgePlugin.purge();
 
 		localThicknessPlugin.setup("", resultImage);
 		localThicknessPlugin.run(null);
 		resultImage = localThicknessPlugin.getResultImage();
+		localThicknessPlugin.purge();
 
 		thicknessCleaningPlugin.setup("", resultImage);
 		thicknessCleaningPlugin.run(null);
 		resultImage = thicknessCleaningPlugin.getResultImage();
+		thicknessCleaningPlugin.purge();
 
 		if (maskThicknessMap) {
 			thicknessMask.inverse = inverse;
 			thicknessMask.threshold = threshold;
 			resultImage = thicknessMask.trimOverhang(inputImage, resultImage);
+			thicknessMask.purge();
 		}
 
 		resultImage.setTitle(originalTitle + titleSuffix);
@@ -188,7 +194,7 @@ public class LocalThicknessWrapper implements PlugInFilter {
 	 * Doing this prevents them from affecting statistical measures calculated
 	 * from the image, e.g. mean pixel value.
 	 *
-	 * @param backgroundValue The color used to identify background pixels
+	 * @param backgroundValue The value used to identify background pixels
 	 *          (usually 0x00)
 	 * @throws NullPointerException If this.resultImage == null
 	 */
@@ -202,14 +208,18 @@ public class LocalThicknessWrapper implements PlugInFilter {
 		final int pixelsPerSlice = resultImage.getWidth() * resultImage.getHeight();
 		final ImageStack stack = resultImage.getStack();
 
+		ArrayList<Integer> sliceNumbers = new ArrayList<>();
 		for (int z = 1; z <= depth; z++) {
-			final float pixels[] = (float[]) stack.getPixels(z);
-			for (int i = 0; i < pixelsPerSlice; i++) {
-				if (Float.compare(pixels[i], backgroundValue) == 0) {
-					pixels[i] = Float.NaN;
-				}
-			}
+			sliceNumbers.add(z);
 		}
+		sliceNumbers.parallelStream().forEach(z -> {
+				final float pixels[] = (float[]) stack.getPixels(z);
+				for (int i = 0; i < pixelsPerSlice; i++) {
+					if (pixels[i] == backgroundValue) {
+						pixels[i] = Float.NaN;
+					}
+				}
+			});
 	}
 
 	/**
@@ -228,12 +238,20 @@ public class LocalThicknessWrapper implements PlugInFilter {
 		final ImageStack stack = resultImage.getStack();
 		final int depth = stack.getSize();
 
+		ArrayList<Integer> sliceNumbers = new ArrayList<>();
 		for (int z = 1; z <= depth; z++) {
-			stack.getProcessor(z).multiply(pixelWidth);
+			sliceNumbers.add(z);
 		}
+		
+		sliceNumbers.parallelStream().forEach(z -> stack.getProcessor(z).multiply(pixelWidth));
 
-		final StackStatistics stackStatistics = new StackStatistics(resultImage);
-		final double maxPixelValue = stackStatistics.max;
+		double[] sliceMax = new double[depth];
+		sliceNumbers.parallelStream().forEach(z -> {
+			sliceMax[z] = stack.getProcessor(z).getMax();
+		});
+		
+		final double maxPixelValue = Arrays.stream(sliceMax).max().getAsDouble();
+		
 		resultImage.getProcessor().setMinAndMax(0, maxPixelValue);
 	}
 

--- a/src/main/java/sc/fiji/localThickness/Local_Thickness_Parallel.java
+++ b/src/main/java/sc/fiji/localThickness/Local_Thickness_Parallel.java
@@ -290,7 +290,7 @@ public class Local_Thickness_Parallel implements PlugInFilter {
 											// sk1[ind1] to something larger than rSquared.
 											// A test shows that this may not be required...
 											synchronized (resources[k1]) {
-												s1 = sk1[ind1];
+												s1 = sk1[ind1];//TODO check that this line is required, s1 is already assigned.
 												if (rSquared > s1) {
 													sk1[ind1] = rSquared;
 												}
@@ -305,4 +305,13 @@ public class Local_Thickness_Parallel implements PlugInFilter {
 			} // k
 		}// run
 	}// Step1Thread
+
+	/**
+	 * Remove references to instance variables to allow garbage collection
+	 */
+	public void purge() {
+		data = null;
+		resultImage = null;
+		imp = null;
+	}
 }

--- a/src/main/java/sc/fiji/localThickness/Local_Thickness_Parallel.java
+++ b/src/main/java/sc/fiji/localThickness/Local_Thickness_Parallel.java
@@ -78,7 +78,6 @@ public class Local_Thickness_Parallel implements PlugInFilter {
 	private ImagePlus imp;
 	private ImagePlus resultImage;
 	public float[][] data;
-	public int w, h, d;
 	public boolean runSilent = false;
 
 	@Override
@@ -92,10 +91,10 @@ public class Local_Thickness_Parallel implements PlugInFilter {
 		resultImage = imp.duplicate();
 		final ImageStack stack = resultImage.getStack();
 
-		w = stack.getWidth();
-		h = stack.getHeight();
-		d = resultImage.getStackSize();
-		final int wh = w * h;
+		final int w = stack.getWidth();
+		final int h = stack.getHeight();
+		final int d = resultImage.getStackSize();
+	
 		// Create reference to input data
 		final float[][] s = new float[d][];
 		for (int k = 0; k < d; k++)
@@ -109,8 +108,9 @@ public class Local_Thickness_Parallel implements PlugInFilter {
 			sk = s[k];
 			nr = 0;
 			for (int j = 0; j < h; j++) {
+				final int wj = w * j;
 				for (int i = 0; i < w; i++) {
-					ind = i + w * j;
+					ind = i + wj;
 					if (sk[ind] > 0) nr++;
 				}
 			}
@@ -134,14 +134,15 @@ public class Local_Thickness_Parallel implements PlugInFilter {
 			rRidgeK = rRidge[k];
 			iR = 0;
 			for (int j = 0; j < h; j++) {
+				final int wj = w * j;
 				for (int i = 0; i < w; i++) {
-					ind = i + w * j;
-					if (sk[ind] > 0) {
-						;
+					ind = i + wj;
+					final float skind = sk[ind];
+					if (skind > 0) {
 						iRidgeK[iR] = i;
 						jRidgeK[iR] = j;
-						rRidgeK[iR++] = sk[ind];
-						if (sk[ind] > sMax) sMax = sk[ind];
+						rRidgeK[iR++] = skind;
+						if (skind > sMax) sMax = skind;
 						sk[ind] = 0;
 					}
 				}
@@ -172,8 +173,9 @@ public class Local_Thickness_Parallel implements PlugInFilter {
 		for (int k = 0; k < d; k++) {
 			sk = s[k];
 			for (int j = 0; j < h; j++) {
+				final int wj = w * j;
 				for (int i = 0; i < w; i++) {
-					ind = i + w * j;
+					ind = i + wj;
 					sk[ind] = (float) (2 * Math.sqrt(sk[ind]));
 				}
 			}
@@ -205,7 +207,7 @@ public class Local_Thickness_Parallel implements PlugInFilter {
 
 	class LTThread extends Thread {
 
-		int thread, nThreads, w, h, d, nR;
+		int thread, nThreads, w, h, d;
 		float[][] s;
 		int[] nRidge;
 		int[][] iRidge, jRidge;
@@ -233,7 +235,6 @@ public class Local_Thickness_Parallel implements PlugInFilter {
 		@Override
 		public void run() {
 			int i, j;
-			final float[] sk;
 			float[] sk1;
 			// Loop through ridge points. For each one, update the local thickness for
 			// the points within its sphere.
@@ -276,11 +277,12 @@ public class Local_Thickness_Parallel implements PlugInFilter {
 						sk1 = s[k1];
 						for (int j1 = jStart; j1 <= jStop; j1++) {
 							r1SquaredJK = r1SquaredK + (j1 - j) * (j1 - j);
+							final int wj1 = w * j1;
 							if (r1SquaredJK <= rSquared) {
 								for (int i1 = iStart; i1 <= iStop; i1++) {
 									r1Squared = r1SquaredJK + (i1 - i) * (i1 - i);
 									if (r1Squared <= rSquared) {
-										ind1 = i1 + w * j1;
+										ind1 = i1 + wj1;
 										s1 = sk1[ind1];
 										if (rSquared > s1) {
 											// Get a lock on sk1 and check again to make sure

--- a/src/main/java/sc/fiji/localThickness/MaskThicknessMapWithOriginal.java
+++ b/src/main/java/sc/fiji/localThickness/MaskThicknessMapWithOriginal.java
@@ -39,12 +39,12 @@ import ij.process.ImageProcessor;
 public class MaskThicknessMapWithOriginal {
 
 	/**
-	 * Pixels with colors &lt; threshold are considered background
+	 * Pixels with values &lt; threshold are considered background
 	 */
 	public int threshold = EDT_S1D.DEFAULT_THRESHOLD;
 
 	/**
-	 * If true, inverts the threshold condition, i.e. color &gt;= threshold is
+	 * If true, inverts the threshold condition, i.e. value &gt;= threshold is
 	 * background
 	 */
 	public boolean inverse = EDT_S1D.DEFAULT_INVERSE;
@@ -105,8 +105,8 @@ public class MaskThicknessMapWithOriginal {
 			resultProcessor = resultStack.getProcessor(z);
 			for (int y = 0; y < h; y++) {
 				for (int x = 0; x < w; x++) {
-					final int color = originalProcessor.get(x, y);
-					if ((color < threshold && !inverse) || (color >= threshold &&
+					final int value = originalProcessor.get(x, y);
+					if ((value < threshold && !inverse) || (value >= threshold &&
 						inverse))
 					{
 						resultProcessor.set(x, y, 0);

--- a/src/main/java/sc/fiji/localThickness/MaskThicknessMapWithOriginal.java
+++ b/src/main/java/sc/fiji/localThickness/MaskThicknessMapWithOriginal.java
@@ -125,4 +125,11 @@ public class MaskThicknessMapWithOriginal {
 	public ImagePlus getResultImage() {
 		return resultImage;
 	}
+
+	/**
+	 * Remove references to instance variables to allow garbage collection
+	 */
+	public void purge() {
+		resultImage = null;
+	}
 }

--- a/src/main/java/sc/fiji/localThickness/MaskThicknessMapWithOriginal.java
+++ b/src/main/java/sc/fiji/localThickness/MaskThicknessMapWithOriginal.java
@@ -22,6 +22,8 @@
 
 package sc.fiji.localThickness;
 
+import java.util.ArrayList;
+
 import ij.IJ;
 import ij.ImagePlus;
 import ij.ImageStack;
@@ -95,14 +97,15 @@ public class MaskThicknessMapWithOriginal {
 
 		final ImageStack originalStack = original.getImageStack();
 		final ImageStack resultStack = resultImage.getImageStack();
-
-		ImageProcessor originalProcessor;
-		ImageProcessor resultProcessor;
+		
+		ArrayList<Integer> sliceNumbers = new ArrayList<>();
 		for (int z = 1; z <= d; z++) {
+			sliceNumbers.add(z);
+		}
+		sliceNumbers.parallelStream().forEach(z -> {
 			IJ.showStatus("Masking thickness map...");
-			IJ.showProgress(z, d);
-			originalProcessor = originalStack.getProcessor(z);
-			resultProcessor = resultStack.getProcessor(z);
+			ImageProcessor originalProcessor = originalStack.getProcessor(z);
+			ImageProcessor resultProcessor = resultStack.getProcessor(z);
 			for (int y = 0; y < h; y++) {
 				for (int x = 0; x < w; x++) {
 					final int value = originalProcessor.get(x, y);
@@ -113,7 +116,7 @@ public class MaskThicknessMapWithOriginal {
 					}
 				}
 			}
-		}
+		});
 
 		return getResultImage();
 	}


### PR DESCRIPTION
The Local Thickness Wrapper creates a number of instances that hold copies of the image data as fields, which are retained until the Wrapper completes execution. This PR adds a `purge()` method to each so that the fields can be set to `null` and the unreferenced data garbage collected. Testing locally suggest that the JRE needs c. 15x the input data size for Local Thickness to complete: this is because 3-4x copies of 4-byte `float` representations are held at any time, along with the input image.

Other micro-optimisations aimed at reducing computation in inner loops appear to have little effect, presumably due to improvements in the JIT compiler since the last time I did this (Java 6).